### PR TITLE
Move react-scripts to devDependencies

### DIFF
--- a/react-paw-mailmerge/package.json
+++ b/react-paw-mailmerge/package.json
@@ -15,9 +15,11 @@
     "react-bootstrap": "^2.10.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3",
-    "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
After looking into the vulnerabilities reported by `npm audit`, I learned that we can safely ignore them, as they're not real vulnerabilities. 
The crux of the issue is that `npm audit` is designed to flag issues that can occur when running Node code in production, but Create React App doesn't produce a Node app, so we're seeing false positives. Since `react-scripts` do not run in production, I moved the dependency to `devDependencies`. `npm audit` will still flag the vulnerabilities, so we should refer to the output of `npm audit --production` instead. 

References:
1. [Help, npm audit says I have a vulnerability in react-scripts!](https://github.com/facebook/create-react-app/issues/11174)
2. [nth-check vulnerability found in react-scripts@4.0.3](https://github.com/facebook/create-react-app/issues/11647#issuecomment-1243863292)
3. https://overreacted.io/npm-audit-broken-by-design/


