### PR TITLE
Bugfix/template reset

### DIFF
--- a/react-paw-mailmerge/src/components/FileUpload.tsx
+++ b/react-paw-mailmerge/src/components/FileUpload.tsx
@@ -5,9 +5,10 @@ import { CsvOptions, CsvResult, ParseCsv } from '../Helpers/CsvFunctions';
 
 interface FileUploadProps {
   setParsedData: React.Dispatch<React.SetStateAction<CsvResult | null>>;
+  resetTemplate: () => void;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({setParsedData}) => {
+const FileUpload: React.FC<FileUploadProps> = ({setParsedData, resetTemplate}) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [dataHasHeader, setDataHasHeader] = useState<boolean>(true);
   const [nullFieldOption, setNullFieldOption] = useState<string>('Ignore');
@@ -43,6 +44,12 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData}) => {
     return errors;
   }
 
+  const onParsingSuccess = (result: CsvResult) => {
+    setParsedData(result);
+    resetTemplate();
+    console.log(result);
+  }
+
   const handleFileUpload = () => {
     if (selectedFile) {
       console.log('Uploading file:', selectedFile);
@@ -52,7 +59,7 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData}) => {
         // proceed to CSV parsing.
         var options = getParserOpts(); // this may need to be adjusted
         //TODO: Write Error callbacks
-        ParseCsv(selectedFile, options, (result) => { setParsedData(result); console.log(result)}, (message, obj) => {
+        ParseCsv(selectedFile, options, onParsingSuccess, (message, obj) => {
           console.error(message);
           console.error(obj);
         });

--- a/react-paw-mailmerge/src/routes/App.tsx
+++ b/react-paw-mailmerge/src/routes/App.tsx
@@ -12,6 +12,17 @@ function App() {
   const [key, setKey] = useState<string>('file-upload');  // maintains state for the UI tabs
   const [parsedData, setParsedData] = useState<CsvResult | null>(null);  // output of the CSV parser function
   const [template, setTemplate] = useState<string>("");  // mail merge template
+  const [reloadKey, setReloadKey] = useState<number>(0);
+
+  const resetTemplate = () => {
+    setTemplate('');
+    // toggle reloadKey to trigger reload
+    if (reloadKey === 0) {
+      setReloadKey(1);
+    } else {
+      setReloadKey(0);
+    }
+  }
 
   return (
     <div>
@@ -23,10 +34,10 @@ function App() {
         className="mb-3"
         >
           <Tab eventKey="file-upload" title="Upload CSV">
-            <FileUpload setParsedData={setParsedData}/>
+            <FileUpload setParsedData={setParsedData} resetTemplate={resetTemplate}/>
           </Tab>
           <Tab eventKey="template" title="Compose Template">
-            <WriteTemplate parsedData={parsedData} template={template} setTemplate={setTemplate}/>
+            <WriteTemplate parsedData={parsedData} template={template} setTemplate={setTemplate} key={reloadKey}/>
           </Tab>
           <Tab eventKey="output" title="View Output">
             <ViewOutput parsedData={parsedData} template={template}/>

--- a/react-paw-mailmerge/src/routes/App.tsx
+++ b/react-paw-mailmerge/src/routes/App.tsx
@@ -12,16 +12,12 @@ function App() {
   const [key, setKey] = useState<string>('file-upload');  // maintains state for the UI tabs
   const [parsedData, setParsedData] = useState<CsvResult | null>(null);  // output of the CSV parser function
   const [template, setTemplate] = useState<string>("");  // mail merge template
-  const [reloadKey, setReloadKey] = useState<number>(0);
+  const [reloadKey, setReloadKey] = useState<number>(0); // trigger WriteTemplate component reload
 
   const resetTemplate = () => {
     setTemplate('');
-    // toggle reloadKey to trigger reload
-    if (reloadKey === 0) {
-      setReloadKey(1);
-    } else {
-      setReloadKey(0);
-    }
+    // toggle reloadKey to reload the entire WriteTemplate component
+    setReloadKey(reloadKey === 0 ? 1 : 0);
   }
 
   return (


### PR DESCRIPTION
Implement `resetTemplate` function which resets the `template` state and reloads the entire `WriteTemplate` component. 
Refactor -- declare a success callback for `ParseCsv` instead of writing the callback inline. 