### PR TITLE
Feature/handle display errors

### DIFF
--- a/react-paw-mailmerge/src/components/FileUpload.tsx
+++ b/react-paw-mailmerge/src/components/FileUpload.tsx
@@ -65,6 +65,7 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData, resetTemplate}) =
     return errors;
   }
 
+  // ParseCsv callback
   const onParsingSuccess = (result: CsvResult) => {
     setParsedData(result);
     resetTemplate();
@@ -137,7 +138,7 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData, resetTemplate}) =
                       />
                   </div>
                 </Form.Group>
-                {successMessage && <PopUpAlert variant={AlertVariant.success} message={successMessage} onClose={dismissSuccessAlert}/>}
+                {successMessage && <PopUpAlert variant={AlertVariant.success} messages={[successMessage]} onClose={dismissSuccessAlert}/>}
                 {errorMessages.length > 0 && <PopUpModal messages={errorMessages} onClose={dismissErrorModal}/>}
                 <Button onClick={handleFileUpload}>Upload File</Button>
             </Form>

--- a/react-paw-mailmerge/src/components/FileUpload.tsx
+++ b/react-paw-mailmerge/src/components/FileUpload.tsx
@@ -71,6 +71,12 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData, resetTemplate}) =
     console.log(result);
   }
 
+  const onParsingFailure = (message: string, obj: object) => {
+    console.error(message);
+    console.error(obj);
+    addErrorMessage([message, JSON.stringify(obj)]);
+  }
+
   const handleFileUpload = () => {
     if (selectedFile) {
       console.log('Uploading file:', selectedFile);
@@ -78,13 +84,9 @@ const FileUpload: React.FC<FileUploadProps> = ({setParsedData, resetTemplate}) =
       const errors = validateFile(selectedFile);
       if (errors.length === 0) {
         // proceed to CSV parsing.
+        setSuccessMessage(`Successfully loaded ${selectedFile.name}.`)
         var options = getParserOpts(); // this may need to be adjusted
-        //TODO: Write Error callbacks
-        ParseCsv(selectedFile, options, onParsingSuccess, (message, obj) => {
-          console.error(message);
-          console.error(obj);
-        });
-    
+        ParseCsv(selectedFile, options, onParsingSuccess, onParsingFailure);
       } else {
         addErrorMessage(errors);
         console.error(errors);

--- a/react-paw-mailmerge/src/components/PopUpAlert.tsx
+++ b/react-paw-mailmerge/src/components/PopUpAlert.tsx
@@ -14,14 +14,14 @@ export enum AlertVariant {
 
 interface PopUpAlertProps {
   variant: AlertVariant;
-  message: string;
+  messages: string[];
   onClose: () => void;
 }
 
-const PopUpAlert: React.FC<PopUpAlertProps> = ({variant, message, onClose }) => {
+const PopUpAlert: React.FC<PopUpAlertProps> = ({variant, messages, onClose }) => {
   return (
     <Alert variant={variant} onClose={onClose} dismissible>
-      {message}
+      {messages.map((message, index) => <p key = {index}>{message}</p>)}
     </Alert>
   );
 };

--- a/react-paw-mailmerge/src/components/PopUpAlert.tsx
+++ b/react-paw-mailmerge/src/components/PopUpAlert.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Alert } from 'react-bootstrap';
+
+export enum AlertVariant {
+  'primary' = 'primary',
+  'secondary' = 'secondary',
+  'success' = 'success',
+  'danger' = 'danger',
+  'warning' = 'warning',
+  'info' = 'info',
+  'light' = 'light',
+  'dark' = 'dark',
+}
+
+interface PopUpAlertProps {
+  variant: AlertVariant;
+  message: string;
+  onClose: () => void;
+}
+
+const PopUpAlert: React.FC<PopUpAlertProps> = ({variant, message, onClose }) => {
+  return (
+    <Alert variant={variant} onClose={onClose} dismissible>
+      {message}
+    </Alert>
+  );
+};
+
+export default PopUpAlert;

--- a/react-paw-mailmerge/src/components/PopUpModal.tsx
+++ b/react-paw-mailmerge/src/components/PopUpModal.tsx
@@ -6,7 +6,7 @@ interface PopUpModalProps {
   onClose: () => void;
 }
 
-const PopUpAlert: React.FC<PopUpModalProps> = ({ messages, onClose }) => {
+const PopUpModal: React.FC<PopUpModalProps> = ({ messages, onClose }) => {
   return (
     <Modal show={true} onHide={onClose} backdrop="static" keyboard={true}>
       <Modal.Header closeButton>
@@ -24,4 +24,4 @@ const PopUpAlert: React.FC<PopUpModalProps> = ({ messages, onClose }) => {
   );
 };
 
-export default PopUpAlert;
+export default PopUpModal;

--- a/react-paw-mailmerge/src/components/PopUpModal.tsx
+++ b/react-paw-mailmerge/src/components/PopUpModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+interface PopUpModalProps {
+  messages: string[];
+  onClose: () => void;
+}
+
+const PopUpAlert: React.FC<PopUpModalProps> = ({ messages, onClose }) => {
+  return (
+    <Modal show={true} onHide={onClose} backdrop="static" keyboard={true}>
+      <Modal.Header closeButton>
+        <Modal.Title>Error</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {messages.map((message, index) => <p key={index}>{message}</p>)}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default PopUpAlert;


### PR DESCRIPTION
This branch contains changes from https://github.com/Cat-1/paw-mailmerge/pull/21
The `ParseCsv` callbacks are now declared as standalone functions.
There are two new components: `PopUpModal` and `PopUpAlert`. I couldn't make them as modular as I wanted them to be, so you'll see some additional state hooks used to control these components content and visibility. 
`PopUpModal` is the one that actually pops up like a vanilla JS alert.