### PR TITLE
Null field error handling

### DIFF
--- a/react-paw-mailmerge/src/Helpers/ZipFunctions.tsx
+++ b/react-paw-mailmerge/src/Helpers/ZipFunctions.tsx
@@ -1,22 +1,25 @@
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver';
+import { MailMergeResult } from './CsvFunctions';
 
 const MAX_FILE_NAME_LEN = 30;
 
-function generateFileName(prefix: number, text: string) {
-    let fileName = text.slice(0, MAX_FILE_NAME_LEN).trim();
+function generateFileName(prefix: number, mailMergeResult : MailMergeResult) {
+    let fileName = mailMergeResult.message.slice(0, MAX_FILE_NAME_LEN).trim();
+
     fileName = fileName.replace(/[^\w\s]/gi, '');  // keep only alpha, nums, underscores, and whitespaces
     fileName = fileName.replace(/\s+/g, '_');  // replace whitespace with underscore
-    fileName = `${prefix}_${fileName}.txt`;
+    const nullValues = mailMergeResult.errors.length > 0 ? "ContainsNullFields_" : "";
+    fileName = `${nullValues}${prefix}_${fileName}.txt`;
     return fileName;
 }
 
-export function ZipAndDownload(outputTexts: string[]): void {
+export function ZipAndDownload(mailMergeResults: Array<MailMergeResult>): void {
     const zip = new JSZip();
 
-    for (let i = 0; i < outputTexts.length; i++) {
-        let fileName = generateFileName(i + 1, outputTexts[i]);  // start the unique numeric id prefix at 1
-        zip.file(fileName, outputTexts[i]);
+    for (let i = 0; i < mailMergeResults.length; i++) {
+        let fileName = generateFileName(i + 1, mailMergeResults[i]);  // start the unique numeric id prefix at 1
+        zip.file(fileName, mailMergeResults[i].message);
     }
 
     zip.generateAsync({type:"blob"}).then(function(content) {

--- a/react-paw-mailmerge/src/components/WriteTemplate.tsx
+++ b/react-paw-mailmerge/src/components/WriteTemplate.tsx
@@ -4,6 +4,7 @@ import Button from "react-bootstrap/Button";
 import { CsvResult, EXTRA_COLUMNS, CheckTemplate } from "../Helpers/CsvFunctions";
 import PopUpAlert from "./PopUpAlert";
 import { AlertVariant } from "./PopUpAlert";
+import { NULL_VAL_REPLACEMENT } from "../Helpers/dist/CsvFunctions";
 
 interface WriteTemplateProps {
     parsedData: CsvResult | null;
@@ -74,7 +75,8 @@ const WriteTemplate: React.FC<WriteTemplateProps> = ({parsedData, template, setT
     }
 
     const buttons = parsedData?.header.map((field:string, index)=>{
-        if(field !== EXTRA_COLUMNS){
+        // if there are null values in the heade row -- don't buttonize them.
+        if(field !== EXTRA_COLUMNS && field !== "" && field !== NULL_VAL_REPLACEMENT){
             return <Button type="button" value={field} onClick={() => addStringToTemplate(field)} key={index} id="{index}-button">{field}</Button>;
         }
         return "";

--- a/react-paw-mailmerge/src/components/WriteTemplate.tsx
+++ b/react-paw-mailmerge/src/components/WriteTemplate.tsx
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 import { CsvResult, EXTRA_COLUMNS, CheckTemplate } from "../Helpers/CsvFunctions";
 import PopUpAlert from "./PopUpAlert";
 import { AlertVariant } from "./PopUpAlert";
-import { NULL_VAL_REPLACEMENT } from "../Helpers/dist/CsvFunctions";
+import { NULL_VAL_REPLACEMENT } from "../Helpers/CsvFunctions";
 
 interface WriteTemplateProps {
     parsedData: CsvResult | null;

--- a/react-paw-mailmerge/src/components/table/TableRow.tsx
+++ b/react-paw-mailmerge/src/components/table/TableRow.tsx
@@ -11,10 +11,13 @@ interface TableRowProps {
 }
 
 const TableRow: React.FC<TableRowProps> = ({rowData, header, maxColumnCount, template}) => {
+    const mailMergeOutput = DoMailMerge(rowData, template);
     const handleViewResult = () => {
-        const mailMergeOutput = DoMailMerge(rowData, template);
-        OpenTextTab(mailMergeOutput);
+        OpenTextTab(mailMergeOutput.message);
     }
+
+    const errorAttributes = mailMergeOutput.errors.length > 0 ? {variant: 'danger', title: "Contains Null Fields"} : {};
+    console.log(errorAttributes);
     return (
         <tr key={JSON.stringify(rowData)}>
             {header
@@ -23,7 +26,7 @@ const TableRow: React.FC<TableRowProps> = ({rowData, header, maxColumnCount, tem
                 (colName) => (<td key={colName}>{rowData[colName]}</td>)
                 )}
             <td>
-                <Button type='button' onClick={handleViewResult}>View Result</Button>
+            <Button type="button" {...errorAttributes} onClick={handleViewResult}>View Result</Button>
             </td>
         </tr>
     )


### PR DESCRIPTION
Reacts to null values in the output files. On the output page, messages with null fields are now "danger" variant buttons. Hover text also provides additional information about the null fields. When the messages are downloaded as a zip file, ContainsNullFields is preprended to file names so that all "bad files" can be easily identified and/or removed because they are all clustered together. Contains minor bug fix for dynamic buttons.